### PR TITLE
Fix for 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
 	modCompileOnly "org.quiltmc.qsl.core:resource_loader:${project.qsl_version}"
 
-	modImplementation("net.devtech:arrp:0.5.7")
+	modCompileOnly("net.devtech:arrp:${project.arrp_version}")
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.17.1
-	yarn_mappings=1.17.1+build.39
-	loader_version=0.11.6
+	minecraft_version=1.19
+	yarn_mappings=1.19+build.1
+	loader_version=0.14.7
 
 # Mod Properties
-	mod_version = 0.3.1
+	mod_version = 0.3.2
 	maven_group = nl.theepicblock
 	archives_base_name = resource-locator-api
 
 # Dependencies
-	fapi_version=0.39.2+1.17
+	fapi_version=0.55.3+1.19
 	qsl_version=1.1.0-beta.4+1.18.2
 	arrp_version=0.5.7

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,10 +8,11 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.11.6
 
 # Mod Properties
-	mod_version = 0.3.0
+	mod_version = 0.3.1
 	maven_group = nl.theepicblock
 	archives_base_name = resource-locator-api
 
 # Dependencies
 	fapi_version=0.39.2+1.17
 	qsl_version=1.1.0-beta.4+1.18.2
+	arrp_version=0.5.7

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -72,7 +72,7 @@ case "`uname`" in
   Darwin* )
     darwin=true
     ;;
-  MSYS* | MINGW* )
+  MINGW* )
     msys=true
     ;;
   NONSTOP* )

--- a/src/main/java/nl/theepicblock/resourcelocatorapi/impl/CompositeResourcePack.java
+++ b/src/main/java/nl/theepicblock/resourcelocatorapi/impl/CompositeResourcePack.java
@@ -102,7 +102,8 @@ public class CompositeResourcePack implements AssetContainer {
         var returnSet = new HashSet<Identifier>();
         for (var pack : this.resourcePacks) {
             for (var namespace : pack.getNamespaces(type)) {
-                returnSet.addAll(pack.findResources(type, namespace, "lang", 1, (path) -> path.endsWith(".json")));
+                Collection<Identifier> identifiers = pack.findResources(type, namespace, "lang", (identifier) -> identifier.getPath().endsWith(".json"));
+                returnSet.addAll(identifiers);
             }
         }
         return returnSet;


### PR DESCRIPTION
The `pack.findResources` method no longer provides a string to the callback, but an identifier.