### PR TITLE
Jitpack: Quilt Loom requires Java 17

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 before_install:
   - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
-  - source install-jdk.sh --feature 16
+  - source install-jdk.sh --feature 17
   - jshell --version


### PR DESCRIPTION
This fixes Jitpack
___
Jitpack Gradle error:
> * What went wrong:
> An exception occurred applying plugin request [id: 'org.quiltmc.loom', version: '0.12.31']
> > Failed to apply plugin 'org.quiltmc.loom'.
>    > You are using an outdated version of Java (16). Java 17 or higher is required.
>      The JAVA_HOME environment variable is currently set to (/home/jitpack/jdk-16.0.1).